### PR TITLE
disable-scouting-opinions

### DIFF
--- a/application/src/scouter/tabs/ScouterTeleoperated.tsx
+++ b/application/src/scouter/tabs/ScouterTeleoperated.tsx
@@ -7,12 +7,6 @@ import { blue } from "@mui/material/colors";
 const ScouterTeleoperated: React.FC = () => {
   return <>
     <ScouterPartialTeleoperated />
-    <div className="defens" style={ {backgroundColor: "#263163"} }>
-        {ScouterInputs.create([
-            ScouterInputs.defense,
-            ScouterInputs.defensiveEvasion,
-          ])}
-    </div>
   </>
 };
 

--- a/application/src/utils/Serde.ts
+++ b/application/src/utils/Serde.ts
@@ -554,11 +554,6 @@ export const qrSerde: FieldsRecordSerde<any> = serdeRecordFieldsBuilder([
   ["endgameCollection", serdeCollectedObjects()],
   ["climb", serdeEnumedString(CLIMB_POSSIBLE_VALUES)],
   ["qual", serdeStringifiedNum(QUAL_BIT_COUNT)],
-  ["defense", serdeOptional(serdeUnsignedInt(DEFENSE_RATING_BIT_COUNT))],
-  [
-    "defensiveEvasion",
-    serdeOptional(serdeUnsignedInt(DEFENSE_RATING_BIT_COUNT)),
-  ],
   ["scouterName", serdeString()],
   ["noShow", serdeBool()],
   ["comment", serdeString()],


### PR DESCRIPTION
Now the scouters cannot give their opinions regarding one team's performence. It is now only possible for super scouters